### PR TITLE
Caching and task to update list.

### DIFF
--- a/rules/disposableemails/classes/local/list_manager.php
+++ b/rules/disposableemails/classes/local/list_manager.php
@@ -16,10 +16,15 @@
 
 namespace registrationrule_disposableemails\local;
 
+// For 4.1 compatibility - this is data_source_interface in later versions.
+use cache_data_source;
+use coding_exception;
 use context_system;
+use core_cache\definition;
 use dml_exception;
 use moodle_exception;
 use file_exception;
+use stored_file;
 
 /**
  * Class managing lists of restricted domains (for disposable mail address restriction).
@@ -32,9 +37,26 @@ use file_exception;
  * @author    Michael Aherne <michael.aherne@strath.ac.uk>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class list_manager {
+class list_manager implements cache_data_source {
+
+    /**
+     * URL of the list of disposable email domains.
+     */
+    const LIST_URL = 'https://raw.githubusercontent.com/' .
+        'disposable-email-domains/disposable-email-domains/' . // User and repository.
+        'master/' . // Branch.
+        'disposable_email_blocklist.conf'; // File to fetch.
+
+    /**
+     * Temporary filename for the list of disposable email domains.
+     */
+    const TEMP_FILENAME = 'disposable_email_blocklist.conf.tmp';
+
     /** @var array files table record */
     private $filerecord;
+
+    /** @var list_manager the singleton instance of this class. */
+    protected static $instance = null;
 
     /**
      * List manager constructor
@@ -59,24 +81,30 @@ class list_manager {
      * @throws file_exception
      * @throws moodle_exception
      */
-    public function get_blocked_domains() {
+    public function get_blocked_domains(): array {
         if (!$this->list_file_exists()) {
             $this->download_list();
         }
         if (!$this->list_file_exists()) {
             throw new moodle_exception('errorlistdownloadfailed', 'registrationrule_disposableemails');
         }
-        $fs = get_file_storage();
-        $file = $fs->get_file(
-            $this->filerecord['contextid'],
-            $this->filerecord['component'],
-            $this->filerecord['filearea'],
-            $this->filerecord['itemid'],
-            $this->filerecord['filepath'],
-            $this->filerecord['filename']
-        );
+
+        $file = $this->get_file();
         $content = $file->get_content();
+
         return explode("\n", $content);
+    }
+
+    /**
+     * Check is a domain is on the list and should be blocked.
+     *
+     * @param string $domain
+     * @return boolean
+     */
+    public function is_domain_blocked(string $domain): bool {
+        // Get an instance of the cache, so we can see if the provided domain exists in it.
+        $cache = \cache::make('registrationrule_disposableemails', 'blockedemaildomains');
+        return $cache->get($domain);
     }
 
     /**
@@ -84,27 +112,50 @@ class list_manager {
      *
      * @return void
      * @throws file_exception
+     * @throws coding_exception
+     * @throws moodle_exception
      */
-    public function download_list() {
+    public function download_list(): void {
         $url = 'https://raw.githubusercontent.com/' .
             'disposable-email-domains/disposable-email-domains/' . // User and repository.
             'master/' . // Branch.
             'disposable_email_blocklist.conf'; // File to fetch.
+        $url = self::LIST_URL;
 
         $fs = get_file_storage();
-        if ($this->list_file_exists()) {
-            $fs->delete_area_files(
-                $this->filerecord['contextid'],
-                $this->filerecord['component'],
-                $this->filerecord['filearea'],
-                $this->filerecord['itemid'],
+
+        if (!$this->list_file_exists()) {
+            $fs->create_file_from_url(
+                $this->filerecord,
+                $url,
             );
+            return;
         }
 
-        $fs->create_file_from_url(
-            $this->filerecord,
-            $url,
+        // If the list already exists, download it to a temporary file first to minimise
+        // the time the list is unavailable.
+        $tempfile = $this->get_file(self::TEMP_FILENAME);
+        if ($tempfile !== false) {
+            $tempfile->delete();
+        }
+
+        $tempfilerecord = $this->filerecord;
+        $tempfilerecord['filename'] = self::TEMP_FILENAME;
+
+        $tempfile = $fs->create_file_from_url(
+            $tempfilerecord,
+            $url
         );
+
+        $realfile = $this->get_file();
+        $realfile->replace_file_with($tempfile);
+        if ($this->list_file_exists()) {
+            $cache = \cache::make('registrationrule_disposableemails', 'blockedemaildomains');
+            $cache->purge();
+            $tempfile->delete();
+        } else {
+            throw new moodle_exception('errorlistdownloadfailed', 'registrationrule_disposableemails');
+        }
     }
 
     /**
@@ -122,5 +173,63 @@ class list_manager {
             $this->filerecord['filepath'],
             $this->filerecord['filename'],
         );
+    }
+
+    /**
+     * Get the given file from this plugin's file area.
+     *
+     * @param string $filename
+     * @return bool|stored_file
+     */
+    private function get_file(string $filename = 'disposable_email_blocklist.conf'): bool|stored_file {
+        $fs = get_file_storage();
+        return $fs->get_file(
+            $this->filerecord['contextid'],
+            $this->filerecord['component'],
+            $this->filerecord['filearea'],
+            $this->filerecord['itemid'],
+            $this->filerecord['filepath'],
+            $filename
+        );
+    }
+
+    /**
+     * Returns an instance of the data source class that the cache can use for loading data using the other methods
+     * specified by this interface.
+     *
+     * @param definition $definition
+     * @return object
+     */
+    public static function get_instance_for_cache(definition $definition): list_manager {
+        if (is_null(self::$instance)) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Loads the data for the key provided ready formatted for caching.
+     *
+     * @param string|int $key The key to load.
+     * @return mixed What ever data should be returned, or false if it can't be loaded.
+     */
+    public function load_for_cache($key): mixed {
+        $blockeddomains = $this->get_blocked_domains();
+        return in_array($key, $blockeddomains);
+    }
+
+    /**
+     * Loads several keys for the cache.
+     *
+     * @param array $keys An array of keys each of which will be string|int.
+     * @return array An array of matching data items.
+     */
+    public function load_many_for_cache(array $keys): array {
+        $blockeddomains = $this->get_blocked_domains();
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = in_array($key, $blockeddomains);
+        }
+        return $result;
     }
 }

--- a/rules/disposableemails/classes/task/update_blocked_domains_list.php
+++ b/rules/disposableemails/classes/task/update_blocked_domains_list.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,10 +12,15 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace registrationrule_disposableemails\task;
+
+use core\task\scheduled_task;
+use registrationrule_disposableemails\local\list_manager;
 
 /**
- * Disposable email usage registration rule version information.
+ * Scheduled task to update the list of blocked email domains.
  *
  * @package   registrationrule_disposableemails
  * @copyright 2024 Catalyst IT Europe {@link https://www.catalyst-eu.net}
@@ -25,12 +30,26 @@
  * @author    Michael Aherne <michael.aherne@strath.ac.uk>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+class update_blocked_domains_list extends scheduled_task {
 
-defined('MOODLE_INTERNAL') || die();
+    /**
+     * Get a descriptive name for the task (shown to admins)
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return get_string('taskupdateblockeddomainslist', 'registrationrule_disposableemails');
+    }
 
-$plugin->version      = 2025030701; // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2022041908; // Support Moodle 4.0 and higher.
-$plugin->component    = 'registrationrule_disposableemails';
-$plugin->release      = 'v0.1';
-$plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = ['tool_registrationrules' => 2024090300];
+    /**
+     * Download a fresh list of domains and purge othe existing cache.
+     *
+     * @return void
+     */
+    public function execute(): void {
+        $listmanager = new list_manager();
+        $listmanager->download_list();
+        $cache = \cache::make('registrationrule_disposableemails', 'blockedemaildomains');
+        $cache->purge();
+    }
+}

--- a/rules/disposableemails/db/caches.php
+++ b/rules/disposableemails/db/caches.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,10 +12,10 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Disposable email usage registration rule version information.
+ * Definition of caches used by the disposable email rule.
  *
  * @package   registrationrule_disposableemails
  * @copyright 2024 Catalyst IT Europe {@link https://www.catalyst-eu.net}
@@ -28,9 +28,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2025030701; // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2022041908; // Support Moodle 4.0 and higher.
-$plugin->component    = 'registrationrule_disposableemails';
-$plugin->release      = 'v0.1';
-$plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = ['tool_registrationrules' => 2024090300];
+use registrationrule_disposableemails\local\list_manager;
+
+$definitions = [
+    'blockedemaildomains' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'datasource' => list_manager::class,
+    ],
+];

--- a/rules/disposableemails/db/tasks.php
+++ b/rules/disposableemails/db/tasks.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - http://moodle.org/
+// This file is part of Moodle - https://moodle.org
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -12,10 +12,10 @@
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Disposable email usage registration rule version information.
+ * Definition of tasks for the disposable email rule.
  *
  * @package   registrationrule_disposableemails
  * @copyright 2024 Catalyst IT Europe {@link https://www.catalyst-eu.net}
@@ -28,9 +28,16 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2025030701; // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires     = 2022041908; // Support Moodle 4.0 and higher.
-$plugin->component    = 'registrationrule_disposableemails';
-$plugin->release      = 'v0.1';
-$plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = ['tool_registrationrules' => 2024090300];
+use registrationrule_disposableemails\task\update_blocked_domains_list;
+
+$tasks = [
+    [
+        'classname' => update_blocked_domains_list::class,
+        'blocking' => 0,
+        'minute' => 'R',
+        'hour' => 'R',
+        'day' => '*',
+        'dayofweek' => 'R',
+        'month' => '*',
+    ],
+];

--- a/rules/disposableemails/lang/en/registrationrule_disposableemails.php
+++ b/rules/disposableemails/lang/en/registrationrule_disposableemails.php
@@ -26,6 +26,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['cachedef_blockedemaildomains'] = 'Blocked email domains';
 $string['errorlistdownloadfailed'] = 'Error downloading disposable email list';
 $string['failuremessage'] = 'Email domain is on a disposable email domain list.';
 $string['fallbackfailuremessage'] = 'Your email address cannot be veriefied at the moment';
@@ -34,3 +35,4 @@ $string['plugindescription'] = 'Check if user email is on a list of disposable e
 $string['pluginname'] = 'Disposable emails';
 $string['privacy:null_provider:reason'] = 'Disposable emails rule does not store any user related data. The domain part of user email addresses will be compared to a list of disposable email domains, this happens transiently during form processing and no data is transmitted.';
 $string['registrationrule:instance:name'] = 'Disposable emails';
+$string['taskupdateblockeddomainslist'] = 'Update blocked domains list';


### PR DESCRIPTION
I've added caching to the disposable emails plugin as promised.

The patch also includes a scheduled task to update the list once per day. This isn't a separate pull request as the way the caching works is quite tightly coupled with the refreshing of the list.

How it works is that the list is updated regularly in the Moodle filestore and the cache is cleared. For each email domain used in a signup attempt the actual list will be checked once and then whether that domain is a disposable one or not will be stored in the cache and used from there until the next refresh of the file. I thought this was a reasonable compromise compared with pre-loading the cache each time the list is refreshed, which is more complex and isn't something that tends to happen much in Moodle.